### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ jobs:
         OVERLEAF_COOKIE: ${{ secrets.OVERLEAF_COOKIE }}
 
     - name: Upload to Project Artifacts
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: project
         path: ./artifacts/


### PR DESCRIPTION
update actions/upload-artifact version
- the old version of [actions/upload-artifact](https://github.com/actions/upload-artifact) is scheduled for deprecation