### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,25 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
+    - name: Delete Old Artifacts
+      uses: actions/github-script@v6
+      id: artifact
+      with:
+        script: |
+          const res = await github.rest.actions.listArtifactsForRepo({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+          })
+
+          res.data.artifacts
+            .forEach(({ id }) => {
+              github.rest.actions.deleteArtifact({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                artifact_id: id,
+              })
+            })
+
     - name: Fetch the latest version from overleaf server
       uses: subhamx/overleaf_sync_with_git@master
       with:
@@ -32,7 +51,7 @@ jobs:
         OVERLEAF_COOKIE: ${{ secrets.OVERLEAF_COOKIE }}
 
     - name: Upload to Project Artifacts
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: project
         path: ./artifacts/


### PR DESCRIPTION
1. update the version of `actions/upload-artifact` from v2 to v4
    - the old version of [actions/upload-artifact](https://github.com/actions/upload-artifact) is scheduled for deprecation
2. add a `delete old artifacts` job at the beginning
    - refer to: [stackoverflow](https://stackoverflow.com/questions/70730786/github-actions-create-artifact-container-failed-artifact-storage-quota-has-b/76859008#76859008)