### PR TITLE
Change cookie name to current value

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,9 +80,9 @@ The project ID of the following URL ```https://www.overleaf.com/project/12345a6b
 This value is a bit trickier to find. It is used to authenticate the action against the Overleaf servers. It is part of the cookie that Overleaf sets in your browser after you successfully login. The process of extracting the required value differs from browser to browser.
 
 In either case open the developer console (Hotkey F12). For Firefox look for the ```Storage``` tab and then select ```Cookies```. For Edge the same setting can be found under ```Application``` and then ```Storage -> Cookies```.
-Look for a cookie with the name ```overleaf_session2``` and copy its value.
+Look for a cookie with the name ```overleaf.sid``` and copy its value.
 
-> **IMPORTANT:** I would recommend that after you copy overleaf_session2 cookie and put it in the GitHub actions secret, please delete the cookie from the browser. And then start a new browser session (by logging in again) if required. **Please do not logout,** it will make overleaf revoke the credentials. If you follow the above point, then the cookie should remain active for atleast 2 months, and the workflow should work without any issues. We've tested it in early 2023 by working a sample workflow for couple of months, and you can find the insights [here](https://github.com/subhamX/overleaf_sync_with_git/pull/4#issuecomment-1355116634).
+> **IMPORTANT:** I would recommend that after you copy overleaf.sid cookie and put it in the GitHub actions secret, please delete the cookie from the browser. And then start a new browser session (by logging in again) if required. **Please do not logout,** it will make overleaf revoke the credentials. If you follow the above point, then the cookie should remain active for atleast 2 months, and the workflow should work without any issues. We've tested it in early 2023 by working a sample workflow for couple of months, and you can find the insights [here](https://github.com/subhamX/overleaf_sync_with_git/pull/4#issuecomment-1355116634).
 
 In the following case, please put `s%3A3xxaFrMMXWi1xxxtm23BjBYJTc8GAb7P.xxyxxzhxxrPJxxovoxxaafnxx9ZorxxP6YxxzxfxxIo` as the OVERLEAF_COOKIE value.
 

--- a/action.yml
+++ b/action.yml
@@ -10,6 +10,9 @@ inputs:
   OVERLEAF_COOKIE: # id of input
     description: "Active Cookie of overleaf account"
     required: true
+  OVERLEAF_COOKIE_KEY: # id of input
+    description: "The key of the cookie, default is overleaf_session2"
+   default: "overleaf_session2"
   OVERLEAF_PROJECT_ID: # id of input
     description: "Id of the project you want the bot to take automatic snapshot"
     required: true
@@ -23,6 +26,7 @@ runs:
   image: "Dockerfile"
   args:
     - ${{ inputs.OVERLEAF_COOKIE }}
+    - ${{ inputs.OVERLEAF_COOKIE_KEY }}
     - ${{ inputs.OVERLEAF_PROJECT_ID }}
     - ${{ inputs.OVERLEAF_HOST }}
 

--- a/src/entrypoint.sh
+++ b/src/entrypoint.sh
@@ -21,7 +21,7 @@ curl "https://$HOST/project/$PROJECT_ID/download/zip" \
   -H 'upgrade-insecure-requests: 1' \
   -H 'accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9' \
   -H 'accept-language: en-US,en;q=0.9' \
-  -H "Cookie: overleaf_session2=$COOKIE" \
+  -H "Cookie: overleaf.sid=$COOKIE" \
   --output "$ZIP_OUTPUT_PATH" --create-dirs
 
 echo "Extracting all files at $EXTRACTED_FILES_PATH"

--- a/src/entrypoint.sh
+++ b/src/entrypoint.sh
@@ -10,6 +10,7 @@ PROJECT_ID="$INPUT_OVERLEAF_PROJECT_ID"
 ZIP_OUTPUT_PATH="${1}/main.zip"
 EXTRACTED_FILES_PATH="./artifacts/"
 COOKIE=$(echo "$INPUT_OVERLEAF_COOKIE" | sed 's/.*=//g')
+COOKIE_KEY="$INPUT_OVERLEAF_COOKIE_KEY"
 HOST="$INPUT_OVERLEAF_HOST"
 
 echo "Dumping zip file at $ZIP_OUTPUT_PATH"
@@ -21,7 +22,7 @@ curl "https://$HOST/project/$PROJECT_ID/download/zip" \
   -H 'upgrade-insecure-requests: 1' \
   -H 'accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9' \
   -H 'accept-language: en-US,en;q=0.9' \
-  -H "Cookie: overleaf.sid=$COOKIE" \
+  -H "Cookie: $COOKIE_KEY=$COOKIE" \
   --output "$ZIP_OUTPUT_PATH" --create-dirs
 
 echo "Extracting all files at $EXTRACTED_FILES_PATH"


### PR DESCRIPTION
In recent versions of overleaf the name of the auth cookie was changed to **overleaf.sid**. 